### PR TITLE
fix: husky pre-commit issue by downgrading it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@commitlint/config-conventional": "^19.2.2",
         "concurrently": "^8.2.2",
         "cross-env": "^7.0.3",
-        "husky": "^9.1.1",
+        "husky": "^9.0.1",
         "lint-staged": "^15.2.2",
         "validate-branch-name": "^1.3.0"
       }
@@ -6209,10 +6209,11 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.1.tgz",
-      "integrity": "sha512-fCqlqLXcBnXa/TJXmT93/A36tJsjdJkibQ1MuIiFyCCYUlpYpIaj2mv1w+3KR6Rzu1IC3slFTje5f6DUp2A2rg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.1.tgz",
+      "integrity": "sha512-rXCT8yF2v3awSG03AG6IgICDhJ+m8o3jL1ROwsT4nQZ6urEyKSj0IWFDIh5YC2zgZeAxWksNMbN6rYY4BE1Zrw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "husky": "bin.js"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@commitlint/config-conventional": "^19.2.2",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
-    "husky": "^9.1.1",
+    "husky": "^9.0.1",
     "lint-staged": "^15.2.2",
     "validate-branch-name": "^1.3.0"
   }


### PR DESCRIPTION
It looks like the pre-commit issue can be circumvented by downgrading `husky` to 9.0.1 then running `npx husky install`
> fyi: I didn't test every version of `husky` after this one to see which one causes the issue